### PR TITLE
Add curiosity and compression intrinsic rewards

### DIFF
--- a/configs/default.yml
+++ b/configs/default.yml
@@ -1,0 +1,7 @@
+intrinsic:
+  curiosity:
+    enabled: true
+    beta: 0.2
+  compression_gain:
+    enabled: true
+    beta: 0.1

--- a/qinf/__init__.py
+++ b/qinf/__init__.py
@@ -1,0 +1,2 @@
+"""Qinf package."""
+__all__ = []

--- a/qinf/intrinsic/__init__.py
+++ b/qinf/intrinsic/__init__.py
@@ -1,0 +1,3 @@
+"""Intrinsic reward modules."""
+from .rewards import CuriosityReward, CompressionGainReward, IntrinsicReward
+__all__ = ["CuriosityReward", "CompressionGainReward", "IntrinsicReward"]

--- a/qinf/intrinsic/rewards.py
+++ b/qinf/intrinsic/rewards.py
@@ -1,0 +1,86 @@
+"""Intrinsic reward functions implemented without third-party dependencies."""
+from __future__ import annotations
+
+import math
+import random
+from typing import Dict, List, Tuple
+
+
+class IntrinsicReward:
+    """Base class for intrinsic reward calculators."""
+
+    def compute(self, obs, next_obs, action, extras) -> float:  # pragma: no cover - interface
+        return 0.0
+
+
+class CuriosityReward(IntrinsicReward):
+    """Random Network Distillation implemented with pure Python.
+
+    A fixed random linear projection (the "target" network) is compared to a
+    trainable linear predictor.  The prediction error after an update serves as
+    a curiosity bonus.
+    """
+
+    def __init__(self, beta: float = 0.2, obs_dim: int | None = None,
+                 feat_dim: int = 16, lr: float = 0.01):
+        self.beta = beta
+        self.obs_dim = obs_dim
+        self.feat_dim = feat_dim
+        self.lr = lr
+        self.target_w: List[List[float]] | None = None
+        self.pred_w: List[List[float]] | None = None
+        if obs_dim is not None:
+            self._init_weights(obs_dim)
+
+    def _init_weights(self, obs_dim: int) -> None:
+        rnd = random.Random(0)
+        self.target_w = [[rnd.uniform(-1, 1) for _ in range(self.feat_dim)] for _ in range(obs_dim)]
+        self.pred_w = [[0.0 for _ in range(self.feat_dim)] for _ in range(obs_dim)]
+
+    def _ensure_weights(self, next_obs) -> None:
+        if self.target_w is None or self.pred_w is None:
+            flat = next_obs["flat"]
+            self.obs_dim = len(flat)
+            self._init_weights(self.obs_dim)
+
+    def _forward(self, weights: List[List[float]], x: List[float]) -> List[float]:
+        return [sum(x[i] * weights[i][j] for i in range(self.obs_dim)) for j in range(self.feat_dim)]
+
+    def compute(self, obs, next_obs, action, extras) -> float:
+        if self.beta == 0.0:
+            return 0.0
+        self._ensure_weights(next_obs)
+        x = next_obs["flat"]
+        phi = self._forward(self.target_w, x)  # type: ignore[arg-type]
+        pred = self._forward(self.pred_w, x)  # type: ignore[arg-type]
+        diff = [pred[j] - phi[j] for j in range(self.feat_dim)]
+        mse = sum(d * d for d in diff) / self.feat_dim
+        # gradient descent update for predictor weights
+        for i in range(self.obs_dim):
+            for j in range(self.feat_dim):
+                grad = 2.0 * diff[j] * x[i] / self.feat_dim
+                self.pred_w[i][j] -= self.lr * grad  # type: ignore[index]
+        return self.beta * mse
+
+
+class CompressionGainReward(IntrinsicReward):
+    """Information gain based on simple frequency counts."""
+
+    def __init__(self, beta: float = 0.1):
+        self.beta = beta
+        self.counts: Dict[Tuple[int, ...], int] = {}
+        self.total = 0
+
+    def _key(self, obs) -> Tuple[int, ...]:
+        return tuple(int(v) for v in obs["flat"])
+
+    def compute(self, obs, next_obs, action, extras) -> float:
+        if self.beta == 0.0:
+            return 0.0
+        key = self._key(next_obs)
+        old_count = self.counts.get(key, 0)
+        # Information gain of updating count from old_count to old_count+1.
+        gain = 0.0 if old_count == 0 else math.log(old_count + 1) - math.log(old_count)
+        self.counts[key] = old_count + 1
+        self.total += 1
+        return self.beta * gain

--- a/tests/test_intrinsic_rewards.py
+++ b/tests/test_intrinsic_rewards.py
@@ -1,0 +1,26 @@
+from qinf.intrinsic import CuriosityReward, CompressionGainReward
+
+
+def test_curiosity_reward_non_zero():
+    r = CuriosityReward(beta=0.5)
+    obs1 = {"flat": [0.0, 0.0, 0.0, 0.0]}
+    obs2 = {"flat": [1.0, 1.0, 1.0, 1.0]}
+    reward = r.compute(obs1, obs2, 0, {})
+    assert reward > 0.0
+
+
+def test_compression_gain_reward_non_zero_after_revisit():
+    r = CompressionGainReward(beta=1.0)
+    obs = {"flat": [1, 2, 3]}
+    _ = r.compute(obs, obs, 0, {})  # first visit -> zero
+    reward = r.compute(obs, obs, 0, {})  # revisit -> positive gain
+    assert reward > 0.0
+
+
+def test_config_toggles_disable_curiosity():
+    cfg = {"intrinsic": {"curiosity": {"enabled": False, "beta": 0.5}}}
+    cur_cfg = cfg["intrinsic"]["curiosity"]
+    r = CuriosityReward(beta=cur_cfg["beta"] if cur_cfg["enabled"] else 0.0)
+    obs1 = {"flat": [0.0, 0.0, 0.0]}
+    obs2 = {"flat": [1.0, 1.0, 1.0]}
+    assert r.compute(obs1, obs2, 0, {}) == 0.0


### PR DESCRIPTION
## Summary
- implement pure-Python Random Network Distillation for curiosity bonuses
- compute compression gain via log count improvement
- expose config toggles and unit tests for intrinsic rewards

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc7eedcc3c83249f2f501e3e81ef8d