### PR TITLE
Add LMDB-backed memory store and ledger logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Q∞ (qinf)
+
+Minimal scaffold for hierarchical + meta-RL with intrinsic rewards and optional persistent memory/ledger.

--- a/configs/default.yml
+++ b/configs/default.yml
@@ -1,0 +1,40 @@
+experiment:
+  id: "toy-grid-hq-meta"
+  seed: 42
+  total_steps: 200000
+  log_every: 1000
+  eval_every: 10000
+
+env:
+  name: "GridWorldToy-v0"
+  size: 8
+  stochasticity: 0.05
+  reward_goal: 1.0
+  reward_step: -0.01
+
+model:
+  qnet: {type: "dueling", hidden: [256, 256]}
+  target_update_interval: 2000
+  double_q: true
+  distributional: false
+
+hierarchy:
+  options:
+    - name: "GoToKey"
+  scheduler: {type: "epsilon_soft", eps_start: 1.0, eps_end: 0.05, eps_steps: 50000}
+
+intrinsic:
+  curiosity: {enabled: true, beta: 0.2}
+  compression_gain: {enabled: true, beta: 0.1}
+
+memory:
+  backend: "lmdb"
+  path: "./runs/memory"
+  ledger_mode: false
+
+optim:
+  lr: 0.00025
+  batch_size: 128
+  gamma: 0.99
+  n_step: 3
+  replay: {capacity: 200000, warmup: 10000, prioritized: false}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "qinf"
+version = "0.0.1"
+description = "Q∞: hierarchical + meta-RL + intrinsic rewards + persistent memory"
+readme = "README.md"
+authors = [{name = "Your Name"}]
+requires-python = ">=3.10"
+dependencies = [
+  "numpy>=1.25",
+  "torch>=2.2",
+  "gymnasium>=0.29",
+  "tqdm>=4.66",
+  "pyyaml>=6.0",
+  "lmdb>=1.4",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["qinf*"]

--- a/qinf/envs/gridtoy.py
+++ b/qinf/envs/gridtoy.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+from typing import Any, Dict
+import numpy as np
+
+A_UP, A_DOWN, A_LEFT, A_RIGHT = 0, 1, 2, 3
+
+
+class GridToy:
+    """Simple grid world environment with a key and goal."""
+
+    def __init__(self, size: int = 8, stochasticity: float = 0.05,
+                 reward_step: float = -0.01, reward_goal: float = 1.0) -> None:
+        self.size = size
+        self.p = stochasticity
+        self.r_step = reward_step
+        self.r_goal = reward_goal
+        self.action_space = 4
+        self.observation_dim = size * size
+        self._rng = np.random.default_rng()
+        self.reset()
+
+    def reset(self, *, seed: int | None = None):
+        if seed is not None:
+            self._rng = np.random.default_rng(seed)
+        self.agent = np.array([0, 0])
+        self.key = np.array([self.size // 2, self.size // 2])
+        self.door = np.array([self.size - 2, self.size - 2])
+        self.goal = np.array([self.size - 1, self.size - 1])
+        self.has_key = False
+        return self._obs(), {}
+
+    def step(self, a: int):
+        a = int(a)
+        if self._rng.random() < self.p:
+            a = self._rng.integers(0, 4)
+        if a == A_UP:
+            self.agent[0] = max(0, self.agent[0] - 1)
+        if a == A_DOWN:
+            self.agent[0] = min(self.size - 1, self.agent[0] + 1)
+        if a == A_LEFT:
+            self.agent[1] = max(0, self.agent[1] - 1)
+        if a == A_RIGHT:
+            self.agent[1] = min(self.size - 1, self.agent[1] + 1)
+        r = self.r_step
+        if (self.agent == self.key).all():
+            self.has_key = True
+        terminated = False
+        if (self.agent == self.goal).all() and self.has_key:
+            r += self.r_goal
+            terminated = True
+        truncated = False
+        return self._obs(), float(r), terminated, truncated, {}
+
+    def _obs(self) -> Dict[str, Any]:
+        flat = np.zeros((self.observation_dim,), dtype=np.float32)
+        idx = self.agent[0] * self.size + self.agent[1]
+        flat[idx] = 1.0
+        obs = {
+            "flat": flat,
+            "needs_key": not self.has_key,
+            "at_key": bool((self.agent == self.key).all()),
+            "at_goal": bool((self.agent == self.goal).all()),
+            "suggested_action_to_key": int(self._rng.integers(0, 4)),
+        }
+        return obs
+
+
+def make_env(**cfg):
+    return GridToy(**cfg)

--- a/qinf/hierarchy/options.py
+++ b/qinf/hierarchy/options.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+
+
+class Option(ABC):
+    @abstractmethod
+    def should_start(self, obs) -> bool:
+        ...
+
+    @abstractmethod
+    def policy(self, obs) -> int:
+        ...
+
+    @abstractmethod
+    def should_terminate(self, obs, step_count: int) -> bool:
+        ...
+
+
+class OptionScheduler(ABC):
+    @abstractmethod
+    def select(self, obs, available_options: list[Option]):
+        ...
+
+
+class GoToKey(Option):
+    def should_start(self, obs) -> bool:
+        return obs.get("needs_key", False)
+
+    def policy(self, obs) -> int:
+        return int(obs.get("suggested_action_to_key", 0))
+
+    def should_terminate(self, obs, t: int) -> bool:
+        return obs.get("at_key", False) or t > 50

--- a/qinf/intrinsic/rewards.py
+++ b/qinf/intrinsic/rewards.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+
+class IntrinsicReward:
+    def compute(self, obs, next_obs, action, extras: dict) -> float:
+        return 0.0
+
+
+class CuriosityReward(IntrinsicReward):
+    def __init__(self, beta: float = 0.2) -> None:
+        self.beta = beta
+
+    def compute(self, obs, next_obs, action, extras: dict) -> float:
+        # Placeholder: no intrinsic reward by default
+        return 0.0
+
+
+class CompressionGainReward(IntrinsicReward):
+    def __init__(self, beta: float = 0.1) -> None:
+        self.beta = beta
+
+    def compute(self, obs, next_obs, action, extras: dict) -> float:
+        return 0.0

--- a/qinf/memory/__init__.py
+++ b/qinf/memory/__init__.py
@@ -1,0 +1,4 @@
+from .store import MemoryStore
+from .lmdb_store import LMDBStore
+
+__all__ = ["MemoryStore", "LMDBStore"]

--- a/qinf/memory/lmdb_store.py
+++ b/qinf/memory/lmdb_store.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import uuid
+import lmdb
+
+from .store import MemoryStore
+
+
+@dataclass
+class LMDBStore(MemoryStore):
+    """MemoryStore backed by an LMDB key-value database."""
+
+    path: Path
+    map_size: int = 1 << 30  # 1GB default
+
+    def __post_init__(self) -> None:
+        self.path.mkdir(parents=True, exist_ok=True)
+        self.env = lmdb.open(str(self.path), map_size=self.map_size, subdir=True, max_dbs=1)
+
+    def put(self, key: bytes, value: bytes) -> None:
+        with self.env.begin(write=True) as txn:
+            txn.put(key, value)
+
+    def get(self, key: bytes) -> bytes | None:
+        with self.env.begin(write=False) as txn:
+            return txn.get(key)
+
+    def commit_snapshot(self, manifest: dict) -> str:
+        snap_id = uuid.uuid4().hex
+        data = json.dumps(manifest).encode("utf-8")
+        self.put(f"snapshot:{snap_id}".encode("utf-8"), data)
+        return snap_id

--- a/qinf/memory/store.py
+++ b/qinf/memory/store.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+
+
+class MemoryStore(ABC):
+    """Abstract key-value store used for persisting run data."""
+
+    @abstractmethod
+    def put(self, key: bytes, value: bytes) -> None:
+        """Store a value under ``key``."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get(self, key: bytes) -> bytes | None:
+        """Retrieve a value for ``key`` if present."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def commit_snapshot(self, manifest: dict) -> str:
+        """Persist a snapshot manifest and return its identifier."""
+        raise NotImplementedError

--- a/qinf/models/qnet.py
+++ b/qinf/models/qnet.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+import torch
+import torch.nn as nn
+
+
+class DuelingQNet(nn.Module):
+    """Minimal dueling architecture Q-network."""
+
+    def __init__(self, obs_dim: int, n_actions: int, hidden: list[int] | None = None) -> None:
+        super().__init__()
+        hidden = hidden or [256, 256]
+        self.body = nn.Sequential(
+            nn.Linear(obs_dim, hidden[0]),
+            nn.ReLU(),
+            nn.Linear(hidden[0], hidden[1]),
+            nn.ReLU(),
+        )
+        self.V = nn.Linear(hidden[1], 1)
+        self.A = nn.Linear(hidden[1], n_actions)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.body(x)
+        v = self.V(h)
+        a = self.A(h)
+        q = v + (a - a.mean(dim=1, keepdim=True))
+        return q

--- a/qinf/runtime/logging.py
+++ b/qinf/runtime/logging.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+import json, time
+
+from qinf.memory.store import MemoryStore
+
+
+@dataclass
+class Logger:
+    """Simple JSONL event logger with optional ledger snapshots."""
+    root: Path
+    run_id: str
+    ledger_mode: bool = False
+    memory: MemoryStore | None = None
+
+    def __post_init__(self) -> None:
+        self.dir = self.root / self.run_id
+        self.dir.mkdir(parents=True, exist_ok=True)
+        (self.dir / "events.jsonl").touch(exist_ok=True)
+
+    def log(self, **kv: Any) -> None:
+        kv = {"t": time.time(), **kv}
+        with (self.dir / "events.jsonl").open("a", encoding="utf-8") as f:
+            f.write(json.dumps(kv) + "\n")
+        if self.ledger_mode and self.memory is not None:
+            self.memory.commit_snapshot(kv)

--- a/qinf/train/learner.py
+++ b/qinf/train/learner.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import torch
+import torch.nn.functional as F
+
+
+class QLearner:
+    def __init__(self, qnet, target_qnet, optim, replay, gamma: float = 0.99,
+                 n_step: int = 1, double_q: bool = True) -> None:
+        self.q, self.tgt, self.opt = qnet, target_qnet, optim
+        self.replay = replay
+        self.gamma = gamma
+        self.n_step = n_step
+        self.double_q = double_q
+        self.step_i = 0
+
+    def step(self, batch):
+        import numpy as np
+
+        s, a, r, s2, d = zip(*batch)
+        s = torch.tensor(np.stack(s)).float()
+        a = torch.tensor(a).long().unsqueeze(1)
+        r = torch.tensor(r).float().unsqueeze(1)
+        s2 = torch.tensor(np.stack(s2)).float()
+        d = torch.tensor(d).float().unsqueeze(1)
+
+        qsa = self.q(s).gather(1, a)
+        with torch.no_grad():
+            if self.double_q:
+                a2 = torch.argmax(self.q(s2), dim=1, keepdim=True)
+                q_next = self.tgt(s2).gather(1, a2)
+            else:
+                q_next, _ = torch.max(self.tgt(s2), dim=1, keepdim=True)
+            target = r + (1.0 - d) * (self.gamma ** self.n_step) * q_next
+        loss = F.smooth_l1_loss(qsa, target)
+        self.opt.zero_grad()
+        loss.backward()
+        self.opt.step()
+        self.step_i += 1
+        return {"loss": float(loss.item())}

--- a/qinf/train/replay.py
+++ b/qinf/train/replay.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+import random
+
+
+class Replay:
+    """Basic FIFO replay buffer."""
+
+    def __init__(self, capacity: int = 200_000, warmup: int = 10_000) -> None:
+        self.capacity = capacity
+        self.warmup = warmup
+        self.buf: list[tuple] = []
+        self.idx = 0
+
+    def add(self, s, a, r, s2, done) -> None:
+        item = (s["flat"], a, r, s2["flat"], done)
+        if len(self.buf) < self.capacity:
+            self.buf.append(item)
+        else:
+            self.buf[self.idx] = item
+            self.idx = (self.idx + 1) % self.capacity
+
+    def ready(self) -> bool:
+        return len(self.buf) >= self.warmup
+
+    def sample(self, batch_size: int):
+        return random.sample(self.buf, batch_size)

--- a/scripts/run_toy.py
+++ b/scripts/run_toy.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+import random
+import yaml
+import torch
+import numpy as np
+from pathlib import Path
+
+from qinf.envs.gridtoy import make_env
+from qinf.models.qnet import DuelingQNet
+from qinf.train.replay import Replay
+from qinf.train.learner import QLearner
+from qinf.hierarchy.options import GoToKey
+from qinf.intrinsic.rewards import CuriosityReward, CompressionGainReward
+from qinf.runtime.logging import Logger
+from qinf.memory.lmdb_store import LMDBStore
+
+
+class EpsilonSoftScheduler:
+    def __init__(self, eps_start: float = 1.0, eps_end: float = 0.05, steps: int = 50_000):
+        self.eps_start, self.eps_end, self.steps = eps_start, eps_end, steps
+        self.t = 0
+
+    def eps(self) -> float:
+        k = max(0.0, (self.steps - self.t) / self.steps)
+        return self.eps_end + (self.eps_start - self.eps_end) * k
+
+    def select(self, obs, opts):
+        self.t += 1
+        use_option = random.random() > self.eps()
+        return random.choice(opts) if (use_option and opts) else None
+
+
+def set_seed(s: int) -> None:
+    random.seed(s)
+    np.random.seed(s)
+    torch.manual_seed(s)
+
+
+def main(cfg_path: str = "configs/default.yml"):
+    cfg = yaml.safe_load(Path(cfg_path).read_text())
+    set_seed(cfg["experiment"]["seed"])
+
+    memory = None
+    if cfg.get("memory", {}).get("ledger_mode"):
+        memory = LMDBStore(Path(cfg["memory"]["path"]))
+
+    logger = Logger(Path("./runs"), cfg["experiment"]["id"],
+                    ledger_mode=cfg.get("memory", {}).get("ledger_mode", False),
+                    memory=memory)
+
+    env = make_env(size=cfg["env"]["size"], stochasticity=cfg["env"]["stochasticity"],
+                   reward_step=cfg["env"]["reward_step"], reward_goal=cfg["env"]["reward_goal"])
+    obs, _ = env.reset()
+    obs_dim, n_actions = env.observation_dim, env.action_space
+
+    q = DuelingQNet(obs_dim, n_actions)
+    tgt = DuelingQNet(obs_dim, n_actions)
+    tgt.load_state_dict(q.state_dict())
+    optim = torch.optim.Adam(q.parameters(), lr=cfg["optim"]["lr"])
+    replay = Replay(capacity=cfg["optim"]["replay"]["capacity"],
+                    warmup=cfg["optim"]["replay"]["warmup"])
+    learner = QLearner(q, tgt, optim, replay,
+                       gamma=cfg["optim"]["gamma"],
+                       n_step=cfg["optim"]["n_step"],
+                       double_q=cfg["model"]["double_q"])
+
+    options = [GoToKey()]
+    scheduler = EpsilonSoftScheduler(**cfg["hierarchy"]["scheduler"])
+    r_cur = CuriosityReward(**cfg["intrinsic"]["curiosity"])
+    r_cmp = CompressionGainReward(**cfg["intrinsic"]["compression_gain"])
+
+    episodic_return, step = 0.0, 0
+    obs, _ = env.reset()
+    while step < cfg["experiment"]["total_steps"]:
+        available = [o for o in options if o.should_start(obs)]
+        opt = scheduler.select(obs, available)
+        if opt is not None:
+            t = 0
+            while True:
+                a = opt.policy(obs)
+                next_obs, r_ext, terminated, truncated, extras = env.step(a)
+                r_int = r_cur.compute(obs, next_obs, a, extras) + r_cmp.compute(obs, next_obs, a, extras)
+                replay.add(obs, a, r_ext + r_int, next_obs, terminated)
+                obs = next_obs
+                episodic_return += r_ext
+                step += 1
+                t += 1
+                if terminated or truncated or opt.should_terminate(obs, t):
+                    break
+        else:
+            x = torch.tensor(obs["flat"]).float().unsqueeze(0)
+            if random.random() < scheduler.eps():
+                a = random.randrange(n_actions)
+            else:
+                a = int(torch.argmax(q(x), dim=1))
+            next_obs, r_ext, terminated, truncated, extras = env.step(a)
+            r_int = r_cur.compute(obs, next_obs, a, extras) + r_cmp.compute(obs, next_obs, a, extras)
+            replay.add(obs, a, r_ext + r_int, next_obs, terminated)
+            obs = next_obs
+            episodic_return += r_ext
+            step += 1
+
+        if replay.ready():
+            logs = learner.step(replay.sample(cfg["optim"]["batch_size"]))
+            if step % cfg["experiment"]["log_every"] == 0:
+                logger.log(step=step, loss=logs["loss"], ret=episodic_return)
+                print(step, logs)
+            if step % cfg["model"]["target_update_interval"] == 0:
+                tgt.load_state_dict(q.state_dict())
+
+        if terminated or truncated:
+            obs, _ = env.reset()
+            episodic_return = 0.0
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add LMDBStore implementing MemoryStore for persistence
- extend Logger with optional ledger mode recording snapshots
- initialize memory store in run_toy when ledger mode is enabled

## Testing
- `python -m py_compile $(rg --files | rg '\.py$')`


------
https://chatgpt.com/codex/tasks/task_e_68bc7ef0a5408324a4e05733cc000348